### PR TITLE
Tests that clearly identify line breaks

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -11,6 +11,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
+    "test-only": "jest --forceExit",
     "test": "jest && npm run lint",
     "lint": "eslint *.js",
     "lint:fix": "eslint --fix *.js",

--- a/lib/tests/acst.test.js
+++ b/lib/tests/acst.test.js
@@ -1,32 +1,36 @@
 const app = require('../index');
 
-const expectedTimezoneObject = `BEGIN:VCALENDAR\r
-PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN\r
-VERSION:2.0\r
-BEGIN:VTIMEZONE\r
-TZID:Australian Central Standard Time\r
-X-LIC-LOCATION:Australian Central Standard Time\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:+0930\r
-TZOFFSETTO:+0930\r
-TZNAME:ACST\r
-DTSTART:19700101T000000\r
-END:STANDARD\r
-END:VTIMEZONE\r
-END:VCALENDAR\r
-`;
+const expectedTimezoneObject = [
+  'BEGIN:VCALENDAR',
+  'PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN',
+  'VERSION:2.0',
+  'BEGIN:VTIMEZONE',
+  'TZID:Australian Central Standard Time',
+  'X-LIC-LOCATION:Australian Central Standard Time',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:+0930',
+  'TZOFFSETTO:+0930',
+  'TZNAME:ACST',
+  'DTSTART:19700101T000000',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  'END:VCALENDAR',
+  '',
+].join('\n');
 
-const expectedTimezoneComponent = `BEGIN:VTIMEZONE\r
-TZID:Australian Central Standard Time\r
-X-LIC-LOCATION:Australian Central Standard Time\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:+0930\r
-TZOFFSETTO:+0930\r
-TZNAME:ACST\r
-DTSTART:19700101T000000\r
-END:STANDARD\r
-END:VTIMEZONE\r
-`;
+const expectedTimezoneComponent = [
+  'BEGIN:VTIMEZONE',
+  'TZID:Australian Central Standard Time',
+  'X-LIC-LOCATION:Australian Central Standard Time',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:+0930',
+  'TZOFFSETTO:+0930',
+  'TZNAME:ACST',
+  'DTSTART:19700101T000000',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  '',
+].join('\n');
 
 test('Correct timezone object for "Australian Central Standard Time" timezone', () => {
   expect(app.getVtimezone('Australian Central Standard Time')).toBe(expectedTimezoneObject);

--- a/lib/tests/bratislava.test.js
+++ b/lib/tests/bratislava.test.js
@@ -1,49 +1,54 @@
 const app = require('../index');
 
-const expectedTimezoneObject = `BEGIN:VCALENDAR\r
-PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN\r
-VERSION:2.0\r
-BEGIN:VTIMEZONE\r
-TZID:Europe/Bratislava\r
-TZURL:http://tzurl.org/zoneinfo-outlook/Europe/Bratislava\r
-X-LIC-LOCATION:Europe/Bratislava\r
-BEGIN:DAYLIGHT\r
-TZOFFSETFROM:+0100\r
-TZOFFSETTO:+0200\r
-TZNAME:CEST\r
-DTSTART:19700329T020000\r
-RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r
-END:DAYLIGHT\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:+0200\r
-TZOFFSETTO:+0100\r
-TZNAME:CET\r
-DTSTART:19701025T030000\r
-RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r
-END:STANDARD\r
-END:VTIMEZONE\r
-END:VCALENDAR\r
-`;
-const expectedTimezoneComponent = `BEGIN:VTIMEZONE\r
-TZID:Europe/Bratislava\r
-TZURL:http://tzurl.org/zoneinfo-outlook/Europe/Bratislava\r
-X-LIC-LOCATION:Europe/Bratislava\r
-BEGIN:DAYLIGHT\r
-TZOFFSETFROM:+0100\r
-TZOFFSETTO:+0200\r
-TZNAME:CEST\r
-DTSTART:19700329T020000\r
-RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r
-END:DAYLIGHT\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:+0200\r
-TZOFFSETTO:+0100\r
-TZNAME:CET\r
-DTSTART:19701025T030000\r
-RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r
-END:STANDARD\r
-END:VTIMEZONE\r
-`;
+const expectedTimezoneObject = [
+  'BEGIN:VCALENDAR',
+  'PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN',
+  'VERSION:2.0',
+  'BEGIN:VTIMEZONE',
+  'TZID:Europe/Bratislava',
+  'TZURL:http://tzurl.org/zoneinfo-outlook/Europe/Bratislava',
+  'X-LIC-LOCATION:Europe/Bratislava',
+  'BEGIN:DAYLIGHT',
+  'TZOFFSETFROM:+0100',
+  'TZOFFSETTO:+0200',
+  'TZNAME:CEST',
+  'DTSTART:19700329T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+  'END:DAYLIGHT',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:+0200',
+  'TZOFFSETTO:+0100',
+  'TZNAME:CET',
+  'DTSTART:19701025T030000',
+  'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  'END:VCALENDAR',
+  '',
+].join('\n');
+
+const expectedTimezoneComponent = [
+  'BEGIN:VTIMEZONE',
+  'TZID:Europe/Bratislava',
+  'TZURL:http://tzurl.org/zoneinfo-outlook/Europe/Bratislava',
+  'X-LIC-LOCATION:Europe/Bratislava',
+  'BEGIN:DAYLIGHT',
+  'TZOFFSETFROM:+0100',
+  'TZOFFSETTO:+0200',
+  'TZNAME:CEST',
+  'DTSTART:19700329T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+  'END:DAYLIGHT',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:+0200',
+  'TZOFFSETTO:+0100',
+  'TZNAME:CET',
+  'DTSTART:19701025T030000',
+  'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  '',
+].join('\n');
 
 test('Correct timezone object for "Europe/Bratislava" timezone', () => {
   expect(app.getVtimezone('Europe/Bratislava')).toBe(expectedTimezoneObject);

--- a/lib/tests/gmt.test.js
+++ b/lib/tests/gmt.test.js
@@ -1,34 +1,38 @@
 const app = require('../index');
 
-const expectedTimezoneObject = `BEGIN:VCALENDAR\r
-PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN\r
-VERSION:2.0\r
-BEGIN:VTIMEZONE\r
-TZID:Etc/GMT\r
-TZURL:http://tzurl.org/zoneinfo-outlook/Etc/GMT\r
-X-LIC-LOCATION:Etc/GMT\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:+0000\r
-TZOFFSETTO:+0000\r
-TZNAME:GMT\r
-DTSTART:19700101T000000\r
-END:STANDARD\r
-END:VTIMEZONE\r
-END:VCALENDAR\r
-`;
+const expectedTimezoneObject = [
+  'BEGIN:VCALENDAR',
+  'PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN',
+  'VERSION:2.0',
+  'BEGIN:VTIMEZONE',
+  'TZID:Etc/GMT',
+  'TZURL:http://tzurl.org/zoneinfo-outlook/Etc/GMT',
+  'X-LIC-LOCATION:Etc/GMT',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:+0000',
+  'TZOFFSETTO:+0000',
+  'TZNAME:GMT',
+  'DTSTART:19700101T000000',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  'END:VCALENDAR',
+  '',
+].join('\n');
 
-const expectedTimezoneComponent = `BEGIN:VTIMEZONE\r
-TZID:Etc/GMT\r
-TZURL:http://tzurl.org/zoneinfo-outlook/Etc/GMT\r
-X-LIC-LOCATION:Etc/GMT\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:+0000\r
-TZOFFSETTO:+0000\r
-TZNAME:GMT\r
-DTSTART:19700101T000000\r
-END:STANDARD\r
-END:VTIMEZONE\r
-`;
+const expectedTimezoneComponent = [
+  'BEGIN:VTIMEZONE',
+  'TZID:Etc/GMT',
+  'TZURL:http://tzurl.org/zoneinfo-outlook/Etc/GMT',
+  'X-LIC-LOCATION:Etc/GMT',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:+0000',
+  'TZOFFSETTO:+0000',
+  'TZNAME:GMT',
+  'DTSTART:19700101T000000',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  '',
+].join('\n');
 
 test('Correct timezone object for "GMT" timezone', () => {
   expect(app.getVtimezone('GMT')).toBe(expectedTimezoneObject);

--- a/lib/tests/new_salem.test.js
+++ b/lib/tests/new_salem.test.js
@@ -1,50 +1,54 @@
 const app = require('../index');
 
-const expectedTimezoneObject = `BEGIN:VCALENDAR\r
-PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN\r
-VERSION:2.0\r
-BEGIN:VTIMEZONE\r
-TZID:America/North_Dakota/New_Salem\r
-TZURL:http://tzurl.org/zoneinfo-outlook/America/North_Dakota/New_Salem\r
-X-LIC-LOCATION:America/North_Dakota/New_Salem\r
-BEGIN:DAYLIGHT\r
-TZOFFSETFROM:-0600\r
-TZOFFSETTO:-0500\r
-TZNAME:CDT\r
-DTSTART:19700308T020000\r
-RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r
-END:DAYLIGHT\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:-0500\r
-TZOFFSETTO:-0600\r
-TZNAME:CST\r
-DTSTART:19701101T020000\r
-RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r
-END:STANDARD\r
-END:VTIMEZONE\r
-END:VCALENDAR\r
-`;
+const expectedTimezoneObject = [
+  'BEGIN:VCALENDAR',
+  'PRODID:-//tzurl.org//NONSGML Olson 2018g-rearguard//EN',
+  'VERSION:2.0',
+  'BEGIN:VTIMEZONE',
+  'TZID:America/North_Dakota/New_Salem',
+  'TZURL:http://tzurl.org/zoneinfo-outlook/America/North_Dakota/New_Salem',
+  'X-LIC-LOCATION:America/North_Dakota/New_Salem',
+  'BEGIN:DAYLIGHT',
+  'TZOFFSETFROM:-0600',
+  'TZOFFSETTO:-0500',
+  'TZNAME:CDT',
+  'DTSTART:19700308T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU',
+  'END:DAYLIGHT',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:-0500',
+  'TZOFFSETTO:-0600',
+  'TZNAME:CST',
+  'DTSTART:19701101T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  'END:VCALENDAR',
+  '',
+].join('\n');
 
-const expectedTimezoneComponent = `BEGIN:VTIMEZONE\r
-TZID:America/North_Dakota/New_Salem\r
-TZURL:http://tzurl.org/zoneinfo-outlook/America/North_Dakota/New_Salem\r
-X-LIC-LOCATION:America/North_Dakota/New_Salem\r
-BEGIN:DAYLIGHT\r
-TZOFFSETFROM:-0600\r
-TZOFFSETTO:-0500\r
-TZNAME:CDT\r
-DTSTART:19700308T020000\r
-RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r
-END:DAYLIGHT\r
-BEGIN:STANDARD\r
-TZOFFSETFROM:-0500\r
-TZOFFSETTO:-0600\r
-TZNAME:CST\r
-DTSTART:19701101T020000\r
-RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r
-END:STANDARD\r
-END:VTIMEZONE\r
-`;
+const expectedTimezoneComponent = [
+  'BEGIN:VTIMEZONE',
+  'TZID:America/North_Dakota/New_Salem',
+  'TZURL:http://tzurl.org/zoneinfo-outlook/America/North_Dakota/New_Salem',
+  'X-LIC-LOCATION:America/North_Dakota/New_Salem',
+  'BEGIN:DAYLIGHT',
+  'TZOFFSETFROM:-0600',
+  'TZOFFSETTO:-0500',
+  'TZNAME:CDT',
+  'DTSTART:19700308T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU',
+  'END:DAYLIGHT',
+  'BEGIN:STANDARD',
+  'TZOFFSETFROM:-0500',
+  'TZOFFSETTO:-0600',
+  'TZNAME:CST',
+  'DTSTART:19701101T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+  '',
+].join('\n');
 
 test('Correct timezone object for "America/North_Dakota/New_Salem" timezone', () => {
   expect(app.getVtimezone('America/North_Dakota/New_Salem')).toBe(expectedTimezoneObject);


### PR DESCRIPTION
If I'm not mistaken, the ics files `lib/zones/**/*.ics` should have `\r\n` line breaks, but actually have `\n` line breaks.

I had freshly checked out the project, installed the npm dependencies and ran the tests, which all failed due to the line endings.

This pull request does not fix this, but it changes the tests to expect `\n` line breaks. This is probably not a desirable solution as the ICS format requires `\r\n` breaks, but the altered tests make it clearer what line breaks are expected and easier to change if required.

To achieve this, I have converted all "expected" test strings to arrays, joined back to a string by the desired line break.

I have also added a new script entry to `package.json`, because the current `test` never exists on my computer. Do the rests work for you?

I intend to submit a few more pull requests soon.